### PR TITLE
When downloading, show download stats including speed and total file size

### DIFF
--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -78,6 +78,7 @@ public struct Shell {
             "--stop-with-process=\(ProcessInfo.processInfo.processIdentifier)",
             "--dir=\(destination.parent.string)",
             "--out=\(destination.basename())",
+            "--human-readable=false", // sets the output to use bytes instead of formatting
             url.absoluteString,
         ]
         let stdOutPipe = Pipe()
@@ -85,7 +86,9 @@ public struct Shell {
         let stdErrPipe = Pipe()
         process.standardError = stdErrPipe
         
-        var progress = Progress(totalUnitCount: 100)
+        var progress = Progress()
+        progress.kind = .file
+        progress.fileOperationKind = .downloading
 
         let observer = NotificationCenter.default.addObserver(
             forName: .NSFileHandleDataAvailable, 
@@ -101,16 +104,7 @@ public struct Shell {
             defer { handle.waitForDataInBackgroundAndNotify() }
 
             let string = String(decoding: handle.availableData, as: UTF8.self)
-            let regex = try! NSRegularExpression(pattern: #"((?<percent>\d+)%\))"#)
-            let range = NSRange(location: 0, length: string.utf16.count)
-
-            guard
-                let match = regex.firstMatch(in: string, options: [], range: range),
-                let matchRange = Range(match.range(withName: "percent"), in: string),
-                let percentCompleted = Int64(string[matchRange])
-            else { return }
-
-            progress.completedUnitCount = percentCompleted
+            progress.updateFromAria2(string: string)
         }
 
         stdOutPipe.fileHandleForReading.waitForDataInBackgroundAndNotify()

--- a/Sources/XcodesKit/Progress+.swift
+++ b/Sources/XcodesKit/Progress+.swift
@@ -1,0 +1,75 @@
+import os.log
+import Foundation
+
+extension Progress {
+    var xcodesLocalizedDescription: String {
+        return localizedAdditionalDescription.replacingOccurrences(of: " — ", with: " | ")
+    }
+    func updateFromAria2(string: String) {
+            
+        let range = NSRange(location: 0, length: string.utf16.count)
+        
+        // MARK: Total Downloaded
+        let regexTotalDownloaded = try! NSRegularExpression(pattern: #"(?<= )(.*)(?=\/)"#)
+        
+        if let match = regexTotalDownloaded.firstMatch(in: string, options: [], range: range),
+            let matchRange = Range(match.range(at: 0), in: string),
+            let totalDownloaded = Int(string[matchRange].replacingOccurrences(of: "B", with: "")) {
+            self.completedUnitCount = Int64(totalDownloaded)
+        }
+        
+        // MARK: Filesize
+        let regexTotalFileSize = try! NSRegularExpression(pattern: #"(?<=/)(.*)(?=\()"#)
+            
+        if let match = regexTotalFileSize.firstMatch(in: string, options: [], range: range),
+           let matchRange = Range(match.range(at: 0), in: string),
+           let totalFileSize = Int(string[matchRange].replacingOccurrences(of: "B", with: "")) {
+                
+            if totalFileSize > 0 {
+                self.totalUnitCount = Int64(totalFileSize)
+            }
+        }
+        
+        // MARK: PERCENT DOWNLOADED
+        // Since we get fractionCompleted from completedUnitCount + totalUnitCount, no need to process
+        // let regexPercent = try! NSRegularExpression(pattern: #"((?<percent>\d+)%\))"#)
+        
+        // MARK: Speed
+        let regexSpeed = try! NSRegularExpression(pattern: #"(?<=DL:)(.*)(?= )"#)
+                    
+        if let match = regexSpeed.firstMatch(in: string, options: [], range: range),
+           let matchRange = Range(match.range(at: 0), in: string),
+           let speed = Int(string[matchRange].replacingOccurrences(of: "B", with: "")) {
+            self.throughput = speed
+        } else {
+            // not showing this as the first few seconds of an aria 2 download will always error out.
+            //Current.logging.log("Could not parse throughput from aria2 download output")
+        }
+        
+        // MARK: Estimated Time Remaining
+        let regexETA = try! NSRegularExpression(pattern: #"(?<=ETA:)(?<hours>\d*h)?(?<minutes>\d*m)?(?<seconds>\d*s)?"#)
+        
+        if let match = regexETA.firstMatch(in: string, options: [], range: range) {
+            var seconds: Int = 0
+            
+            if let matchRange = Range(match.range(withName: "hours"), in: string),
+               let hours = Int(string[matchRange].replacingOccurrences(of: "h", with: "")) {
+                seconds += (hours * 60 * 60)
+            }
+            
+            if let matchRange = Range(match.range(withName: "minutes"), in: string),
+               let minutes = Int(string[matchRange].replacingOccurrences(of: "m", with: "")) {
+                seconds += (minutes * 60)
+            }
+            
+            if let matchRange = Range(match.range(withName: "seconds"), in: string),
+               let second = Int(string[matchRange].replacingOccurrences(of: "s", with: "")) {
+                seconds += (second)
+            }
+            
+            self.estimatedTimeRemaining = TimeInterval(seconds)
+        }
+        
+    }
+}
+


### PR DESCRIPTION
Closes #163 

This will add the aria 2 stats that is used on XcodesApp to make the download feel a bit more polished.

<img width="1352" alt="(16) Downioading Xcode 13 2 0+13C90" src="https://user-images.githubusercontent.com/1119565/146313941-10c980d1-b957-40e0-81f2-a6bc1b2df39b.png">

Also added a few console prints - to show which service is used for downloading, and, when on urlSession, let users know downloads will be faster if they install aria2

