### PR TITLE
Converting all top-level commands to async

### DIFF
--- a/Sources/XcodesKit/PromiseKit+Async.swift
+++ b/Sources/XcodesKit/PromiseKit+Async.swift
@@ -1,7 +1,7 @@
 import PromiseKit
 
 extension Promise {
-    func async() async throws -> T {
+    public func async() async throws -> T {
         return try await withCheckedThrowingContinuation { continuation in
             done { value in
                 continuation.resume(returning: value)
@@ -13,7 +13,7 @@ extension Promise {
 }
 
 extension Guarantee {
-    func async() async -> T {
+    public func async() async -> T {
         return await withCheckedContinuation { continuation in
             done { value in
                 continuation.resume(returning: value)


### PR DESCRIPTION
Converting all top-level commands to `async` in preparation to also convert the implementations in a later PR