### PR TITLE
Always respect select flag during install

### DIFF
--- a/Sources/xcodes/App.swift
+++ b/Sources/xcodes/App.swift
@@ -290,6 +290,16 @@ struct Xcodes: AsyncParsableCommand {
                     return xcodeInstaller.install(installation, dataSource: globalDataSource.dataSource, downloader: downloader, destination: destination, experimentalUnxip: experimentalUnxip, emptyTrash: emptyTrash, noSuperuser: noSuperuser)
                 }
             }
+            .recover { error -> Promise<InstalledXcode> in
+                if select, case let XcodeInstaller.Error.versionAlreadyInstalled(installedXcode) = error {
+                    Current.logging.log(error.legibleLocalizedDescription.green)
+                    return Promise { seal in
+                        seal.fulfill(installedXcode)
+                    }
+                } else {
+                    throw error
+                }
+            }
             .then { xcode -> Promise<Void> in
                 if select {
                     return selectXcode(shouldPrint: print, pathOrVersion: xcode.path.string, directory: destination, fallbackToInteractive: false)


### PR DESCRIPTION
Resolves https://github.com/XcodesOrg/xcodes/issues/236

If the specified version of Xcode was already installed, the `--select` flag was only respected in the variant that passed a version number.
`xcodes install 14.3.1 --select`

This PR fixes the `--select` flag for the other install cases.
`xcodes install --select`
`xcodes install --latest --select`
`xcodes install --latest-prerelease --select`