### PR TITLE
Add support for SRP Apple login

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "big-num",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/big-num",
+      "state" : {
+        "revision" : "5c5511ad06aeb2b97d0868f7394e14a624bfb1c7",
+        "version" : "2.0.2"
+      }
+    },
+    {
       "identity" : "data",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xcodereleases/data",
@@ -69,6 +78,24 @@
       "state" : {
         "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
+      "identity" : "swift-srp",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/xcodesorg/swift-srp",
+      "state" : {
+        "branch" : "main",
+        "revision" : "543aa0122a0257b992f6c7d62d18a26e3dffb8fe"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/xcodereleases/data", revision: "fcf527b187817f67c05223676341f3ab69d4214d"),
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMinor(from: "3.2.0")),
         .package(url: "https://github.com/jpsim/Yams", .upToNextMinor(from: "5.0.1")),
+        .package(url: "https://github.com/xcodesOrg/swift-srp", branch: "main")
     ],
     targets: [
         .executableTarget(
@@ -50,7 +51,7 @@ let package = Package(
                 "Version",
                 .product(name: "XCModel", package: "data"),
                 "Rainbow",
-                "Yams",
+                "Yams"
             ]),
         .testTarget(
             name: "XcodesKitTests",
@@ -68,6 +69,7 @@ let package = Package(
                 "PromiseKit",
                 .product(name: "PMKFoundation", package: "Foundation"),
                 "Rainbow",
+                .product(name: "SRP", package: "swift-srp")
             ]),
         .testTarget(
             name: "AppleAPITests",

--- a/Sources/AppleAPI/Client.swift
+++ b/Sources/AppleAPI/Client.swift
@@ -61,6 +61,9 @@ public class Client {
             }
     }
     
+    /// SRPLogin - Secure Remote Password
+    /// https://tools.ietf.org/html/rfc2945
+    /// Forked from https://github.com/adam-fowler/swift-srp that provides the algorithm
     public func srpLogin(accountName: String, password: String) -> Promise<Void> {
         var serviceKey: String!
         let client = SRPClient(configuration: SRPConfiguration<SHA256>(.N2048))

--- a/Sources/AppleAPI/URLRequest+Apple.swift
+++ b/Sources/AppleAPI/URLRequest+Apple.swift
@@ -9,6 +9,9 @@ extension URL {
     static func submitSecurityCode(_ code: SecurityCode) -> URL { URL(string: "https://idmsa.apple.com/appleauth/auth/verify/\(code.urlPathComponent)/securitycode")! }
     static let trust = URL(string: "https://idmsa.apple.com/appleauth/auth/2sv/trust")!
     static let olympusSession = URL(string: "https://appstoreconnect.apple.com/olympus/v1/session")!
+    
+    static let srpInit = URL(string: "https://idmsa.apple.com/appleauth/auth/signin/init")!
+    static let srpComplete = URL(string: "https://idmsa.apple.com/appleauth/auth/signin/complete?isRememberMeEnabled=false")!
 }
 
 extension URLRequest {
@@ -129,4 +132,49 @@ extension URLRequest {
         
         return request
     }
+    
+    static func SRPInit(serviceKey: String, a: String, accountName: String) -> URLRequest {
+        struct ServerSRPInitRequest: Encodable {
+            public let a: String
+            public let accountName: String
+            public let protocols: [SRPProtocol]
+        }
+        
+        var request = URLRequest(url: .srpInit)
+        request.httpMethod = "POST"
+        request.allHTTPHeaderFields = request.allHTTPHeaderFields ?? [:]
+        request.allHTTPHeaderFields?["Accept"] = "application/json"
+        request.allHTTPHeaderFields?["Content-Type"] = "application/json"
+        request.allHTTPHeaderFields?["X-Requested-With"] = "XMLHttpRequest"
+        request.allHTTPHeaderFields?["X-Apple-Widget-Key"] = serviceKey
+        
+        request.httpBody = try? JSONEncoder().encode(ServerSRPInitRequest(a: a, accountName: accountName, protocols: [.s2k, .s2k_fo]))
+        return request
+    }
+    
+    static func SRPComplete(serviceKey: String, hashcash: String, accountName: String, c: String, m1: String, m2: String) -> URLRequest {
+        struct ServerSRPCompleteRequest: Encodable {
+            let accountName: String
+            let c: String
+            let m1: String
+            let m2: String
+            let rememberMe: Bool
+        }
+        
+        var request = URLRequest(url: .srpComplete)
+        request.httpMethod = "POST"
+        request.allHTTPHeaderFields = request.allHTTPHeaderFields ?? [:]
+        request.allHTTPHeaderFields?["Accept"] = "application/json"
+        request.allHTTPHeaderFields?["Content-Type"] = "application/json"
+        request.allHTTPHeaderFields?["X-Requested-With"] = "XMLHttpRequest"
+        request.allHTTPHeaderFields?["X-Apple-Widget-Key"] = serviceKey
+        request.allHTTPHeaderFields?["X-Apple-HC"] = hashcash
+        
+        request.httpBody = try? JSONEncoder().encode(ServerSRPCompleteRequest(accountName: accountName, c: c, m1: m1, m2: m2, rememberMe: false))
+        return request
+    }
+}
+
+public enum SRPProtocol: String, Codable {
+    case s2k, s2k_fo
 }

--- a/Sources/XcodesKit/Environment.swift
+++ b/Sources/XcodesKit/Environment.swift
@@ -300,7 +300,7 @@ public struct Network {
 
     public var validateSession: () -> Promise<Void> = client.validateSession
 
-    public var login: (String, String) -> Promise<Void> = { client.login(accountName: $0, password: $1) }
+    public var login: (String, String) -> Promise<Void> = { client.srpLogin(accountName: $0, password: $1) }
     public func login(accountName: String, password: String) -> Promise<Void> {
         login(accountName, password)
     }


### PR DESCRIPTION
Apple switched up their login to now use a Secure Remote Password type of algorithm. This add support for it, so a user can login properly.

Fixes #388 

