### PR TITLE
Add support for local cryptex disk images

### DIFF
--- a/Sources/XcodesKit/Models+Runtimes.swift
+++ b/Sources/XcodesKit/Models+Runtimes.swift
@@ -129,8 +129,9 @@ public struct InstalledRuntime: Decodable {
 
 extension InstalledRuntime {
     enum Kind: String, Decodable {
-        case diskImage = "Disk Image"
         case bundled = "Bundled with Xcode"
+        case cryptexDiskImage = "Cryptex Disk Image"
+        case diskImage = "Disk Image"
         case legacyDownload = "Legacy Download"
     }
 

--- a/Sources/XcodesKit/RuntimeInstaller.swift
+++ b/Sources/XcodesKit/RuntimeInstaller.swift
@@ -78,7 +78,7 @@ public class RuntimeInstaller {
                 if runtime.hasDuplicateVersion {
                     str += " (\(runtime.build))"
                 }
-                if runtime.state == .legacyDownload || runtime.state == .diskImage {
+                if runtime.state == .legacyDownload || runtime.state == .diskImage || runtime.state == .cryptexDiskImage {
                     str += " (Installed)"
                 } else if runtime.state == .bundled {
                     str += " (Bundled with selected Xcode)"


### PR DESCRIPTION
If recent runtimes are installed (18.4, possibly 18.3.1), xcodes can no longer list (or install?) runtimes.

Resolves #421 