### PR TITLE
use the correct org name

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,7 +11,7 @@ categories:
       - 'documentation'
       - 'dependencies'
 template: |
-  If you installed xcodes with homebrew you can upgrade with `brew upgrade robotsandpencils/made/xcodes`.
+  If you installed xcodes with homebrew you can upgrade with `brew upgrade xcodesorg/made/xcodes`.
 
   ## Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Pull requests are the best way to propose changes to the codebase  We actively w
 ## Any contributions you make will be under the MIT Software License
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues](https://github.com/robotsandpencils/xcodes/issues)
+## Report bugs using Github's [issues](https://github.com/xcodesorg/xcodes/issues)
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](); it's that easy!
 
 ## Write bug reports with detail, background, and sample code


### PR DESCRIPTION
Hi!

Noticed that the [Release description](https://github.com/XcodesOrg/xcodes/releases/tag/1.6.1) references the original `robotsandpencils` organization. Changed it to the `xcodesorg` in the corresponding github release template.

`grep -R robotsandpencils` shows some other places, where `robotsandpencils` is referenced. I'm sure that the one in the `CONTRIBUTING.md` should be updated.

As for the rest, I've left them untouched, as I'm afraid, they might require some migration code:
 - XcodesKitTests.swift
 - LogOutput-DamagedXIP.txt
 - Environment.swift
 - Path+.swift