### PR TITLE
Add patchable cryptex disk image handling

### DIFF
--- a/Sources/XcodesKit/Models+Runtimes.swift
+++ b/Sources/XcodesKit/Models+Runtimes.swift
@@ -80,6 +80,7 @@ extension DownloadableRuntime {
         case diskImage = "diskImage"
         case package = "package"
         case cryptexDiskImage = "cryptexDiskImage"
+        case patchableCryptexDiskImage = "patchableCryptexDiskImage"
     }
 
     enum Platform: String, Decodable {
@@ -133,6 +134,7 @@ extension InstalledRuntime {
         case cryptexDiskImage = "Cryptex Disk Image"
         case diskImage = "Disk Image"
         case legacyDownload = "Legacy Download"
+        case patchableCryptexDiskImage = "Patchable Cryptex Disk Image"
     }
 
     enum Platform: String, Decodable {


### PR DESCRIPTION
This one's a fast-follow to #423. The just-released `iOS 26.0-beta1` runtime, when installed, reports its `kind` as `"Patchable Crypex Disk Image"`.

I also added an enum case to the runtime API endpoint's `contentType`, though I don't think that's strictly necessary—the API still parses fine as-is (i.e. the 26.0b1 runtimes are parsed as `cryptexDiskImage`)